### PR TITLE
Add build job in ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   build-python:
-    name: build-python / ${{ matrix.os }} / x86_64
+    name: build-python / x86_64 / ${{ matrix.os }} / Python${{ matrix.python }}
     if: github.repository_owner == 'awslabs'
     strategy:
       fail-fast: false
@@ -55,6 +55,7 @@ jobs:
           make init
 
       - name: Test
+        shell: bash
         run: |
           ZION_VERSION=$(python -c "import pkg_resources;print(pkg_resources.get_distribution('zion').version)")
           [ -f ./python-client/dist/zion-${ZION_VERSION}.tar.gz ]


### PR DESCRIPTION
**Issue number:**
N/A

## Summary

Add build into CI Workflow. This job aims to validate both the service and python client can be build in different OS properly.

Note: GH Actions only supports x86_64 now. See https://github.com/actions/runner-images/issues?q=is%3Aissue+is%3Aopen+arm

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

#### Mandatory Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.