### PR TITLE
change condition to assertion_fn

### DIFF
--- a/python-client/src/zion/__init__.py
+++ b/python-client/src/zion/__init__.py
@@ -312,7 +312,7 @@ class Zion:
         LOG.debug(f"Output: {output}")
         return output
 
-    def wait_until_event_matched(self, listener_id: str, condition: Callable[[str], bool], timeout_seconds: int = 30) -> bool:
+    def wait_until_event_matched(self, listener_id: str, assertion_fn: Callable[[str], None], timeout_seconds: int = 30) -> bool:
         """
         Poll Events on a given Listener until a match is found or timeout met.
 
@@ -330,8 +330,8 @@ class Zion:
         ----------
         listener_id : str
             Id of the Listener that was created
-        condition : Callable[[str], bool]
-            Callable fuction that takes a str and returns a bool
+        assertion_fn : Callable[[str], bool]
+            Callable function that has an assertion and raises an AssertionError if it fails
         timeout_seconds : int
             Timeout (in seconds) to stop the polling
         
@@ -345,7 +345,7 @@ class Zion:
         ZionException
             When failed to Poll Events
         """
-        params = WaitUntilEventMatchedParams(listener_id, condition, timeout_seconds)
+        params = WaitUntilEventMatchedParams(listener_id, assertion_fn, timeout_seconds)
         start = datetime.now()
         elapsed = lambda _: (datetime.now() - start).total_seconds()
         while elapsed(None) < params.timeout_seconds:
@@ -353,9 +353,12 @@ class Zion:
             events = out.events
             if events:
                 for event in events:
-                    if params.condition(event):
+                    try: 
+                        params.assertion_fn(event)
                         LOG.debug("event matched")
                         return True
+                    except AssertionError:
+                        pass
 
         LOG.debug(f"timeout after {params.timeout_seconds} seconds")
         LOG.debug("no matching event found")
@@ -465,7 +468,7 @@ class Zion:
 
         return GenerateMockEventOutput(event)
     
-    def retry_until(self, condition, timeout = 10, retryable_exceptions = (RetryableException,)):
+    def retry_until(self, assertion_fn, timeout = 10, retryable_exceptions = (RetryableException,)):
         """
         Decorator function to retry until condition or timeout is met
 
@@ -474,8 +477,8 @@ class Zion:
         
         Parameters
         ----------
-        condition: Callable[[any], bool]
-            Callable function that takes any type and returns a bool
+        assertion_fn: Callable[[any], None]
+            Callable function that has an assertion and raises an AssertionError if it fails
         timeout: int or float
             value that specifies how long the function will retry for until it times out
         
@@ -495,8 +498,8 @@ class Zion:
             raise TypeError("timeout must be an int or float")
         elif(timeout < 0):
             raise ValueError("timeout must not be a negative value")
-        if(not callable(condition)):
-            raise TypeError("condition is not a callable function")
+        if(not callable(assertion_fn)):
+            raise TypeError("assertion_fn is not a callable function")
         def retry_until_decorator(func):
             @wraps(func)
             def _wrapper(*args, **kwargs):
@@ -511,8 +514,11 @@ class Zion:
                         output = func(*args, **kwargs)
                     except retryable_exceptions:
                         continue
-                    if condition(output):
+                    try:
+                        assertion_fn(output)
                         return True
+                    except AssertionError:
+                        pass
                     time.sleep(math.pow(2, attempt) * delay)
                     attempt += 1
                 LOG.debug(f"timeout after {timeout} seconds")
@@ -601,7 +607,7 @@ class Zion:
             raise ZionException(message=message, error_code=error_code)
 
         
-    def retry_get_trace_tree_until(self, tracing_header: str, condition: Callable[[GetTraceTreeOutput], bool], timeout_seconds: int = 30):
+    def retry_get_trace_tree_until(self, tracing_header: str, assertion_fn: Callable[[GetTraceTreeOutput], None], timeout_seconds: int = 30):
         """
         function to retry get_trace_tree condition or timeout is met
 
@@ -613,7 +619,7 @@ class Zion:
         ----------
         trace_header:
             x-ray trace header
-        condition : Callable[[GetTraceTreeOutput], bool]
+        assertion_fn : Callable[[GetTraceTreeOutput], None]
             Callable fuction that takes a str and returns a bool
         timeout_seconds : int
             Timeout (in seconds) to stop the fetching
@@ -628,8 +634,8 @@ class Zion:
         Zionexception
             When an exception occurs during get_trace_tree
         """
-        params = RetryGetTraceTreeUntilParams(tracing_header, condition, timeout_seconds)
-        @self.retry_until(condition=params.condition, timeout=params.timeout_seconds)
+        params = RetryGetTraceTreeUntilParams(tracing_header, assertion_fn, timeout_seconds)
+        @self.retry_until(assertion_fn=params.assertion_fn, timeout=params.timeout_seconds)
         def fetch_trace_tree():
             try:
                 response = self._get_trace_tree(

--- a/python-client/src/zion/poll_events.py
+++ b/python-client/src/zion/poll_events.py
@@ -70,12 +70,12 @@ class WaitUntilEventMatchedParams:
     ----------
     listener_id : str
         Id of the Listener that was created
-    condition : Callable[[str], bool]
+    assertion_fn : Callable[[str], None]
         Callable fuction that takes a str and returns a bool
     timeout_seconds : int
         Timeout (in seconds) to stop the polling
     """
-    condition: Callable[[str], bool]    
+    assertion_fn: Callable[[str], None]    
     timeout_seconds: int
 
     _poll_event_params: PollEventsParams
@@ -83,13 +83,13 @@ class WaitUntilEventMatchedParams:
     def __init__(
         self,
         listener_id: str,
-        condition: Callable[[str], bool],
+        assertion_fn: Callable[[str], None],
         timeout_seconds: int = 30,
     ):
         if timeout_seconds <= 0 or timeout_seconds > 999:
             raise InvalidParamException("timeout_seconds must be between 1 and 999")
 
-        self.condition = condition
+        self.assertion_fn = assertion_fn
         self.timeout_seconds = timeout_seconds
 
         self._poll_event_params = PollEventsParams(

--- a/python-client/src/zion/retry_xray_trace.py
+++ b/python-client/src/zion/retry_xray_trace.py
@@ -25,17 +25,17 @@ class RetryGetTraceTreeUntilParams:
     timeout_seconds : int
         Timeout (in seconds) to stop the fetching
     """
-    condition: Callable[[GetTraceTreeOutput], bool]    
+    assertion_fn: Callable[[GetTraceTreeOutput], None]    
     timeout_seconds: int
     tracing_header: str
 
     def __init__(
         self,
         tracing_header: str,
-        condition: Callable[[GetTraceTreeOutput], bool],
+        assertion_fn: Callable[[GetTraceTreeOutput], None],
         timeout_seconds: int = 30,
     ):
-        self.condition = condition
+        self.assertion_fn = assertion_fn
         self.timeout_seconds = timeout_seconds
         self.tracing_header = tracing_header
 

--- a/python-client/tests/integration/retry_fetch_trace/test_retry_fetch_until.py
+++ b/python-client/tests/integration/retry_fetch_trace/test_retry_fetch_until.py
@@ -76,7 +76,7 @@ class TestZion_retry_fetch_until(TestCase):
         start = time.time()
         response = self.zion.retry_get_trace_tree_until(
             tracing_header=self.xray_trace_header,
-            condition=trace_header_is_root,
+            assertion_fn=trace_header_is_root,
             timeout_seconds=10
         )
         end = time.time()
@@ -87,11 +87,11 @@ class TestZion_retry_fetch_until(TestCase):
         time.sleep(5)
         def num_is_10(trace):
             self.counter = random.randrange(0,10)
-            return self.counter == 10
+            assert self.counter == 10
         start = time.time()
         response = self.zion.retry_get_trace_tree_until(
             tracing_header=self.xray_trace_header,
-            condition=num_is_10,
+            assertion_fn=num_is_10,
             timeout_seconds=10
         )
         end = time.time()
@@ -105,11 +105,11 @@ class TestZion_retry_fetch_until(TestCase):
         def num_is_10(trace):
             time.sleep(1.5)
             self.counter += 1
-            return self.counter == 10
+            assert self.counter == 10
         start = time.time()
         response = self.zion.retry_get_trace_tree_until(
             tracing_header=self.xray_trace_header,
-            condition=num_is_10,
+            assertion_fn=num_is_10,
             timeout_seconds=0
         )
         end = time.time()
@@ -120,21 +120,21 @@ class TestZion_retry_fetch_until(TestCase):
     def test_invalid_traceid_fail(self):
         def num_is_10(trace):
             self.counter = random.randrange(0,10)
-            return self.counter == 10
+            assert self.counter == 10
         with pytest.raises(zion.ZionException) as e:
             self.zion.retry_get_trace_tree_until(
                 tracing_header="test",
-                condition=num_is_10,
+                assertion_fn=num_is_10,
                 timeout_seconds=10
             )
         self.assertNotEqual(self.counter, 10)
         self.assertIn("error while getting trace_id from", str(e.value))
 
-    def test_condition_not_function_error(self):
+    def test_assertion_fn_not_function_error(self):
         with pytest.raises(TypeError) as e:
             self.zion.retry_get_trace_tree_until(
                 tracing_header=self.xray_trace_header,
-                condition=0,
+                assertion_fn=0,
                 timeout_seconds=10
             )
             self.assertNotEqual(self.counter, 10)
@@ -142,11 +142,11 @@ class TestZion_retry_fetch_until(TestCase):
 
     def test_retry_trace_not_found(self):
         def num_is_5(trace):
-            return random.randrange(0,5) == 5
+            assert random.randrange(0,5) == 5
         start = time.time()
         response = self.zion.retry_get_trace_tree_until(
             tracing_header="Root=1-652850da-255d5ae071f55e4aef339837;Sampled=1",
-            condition=num_is_5,
+            assertion_fn=num_is_5,
             timeout_seconds=10
         )
         end = time.time()

--- a/python-client/tests/integration/test_harness/eventbridge/poll_events/test_wait_until_event_matched.py
+++ b/python-client/tests/integration/test_harness/eventbridge/poll_events/test_wait_until_event_matched.py
@@ -39,39 +39,36 @@ class EbEvent:
         }
 
 
-def condition_func_0(received: str) -> bool:
+def assertion_func_0(received: str) -> None:
     LOG.debug("received: %s", received)
     payload = json.loads(received)
     try:
         detail = payload["detail"]
         detail_type = payload["detail-type"]
         source = payload["source"]
-        matched = (
-            detail["abc"] == "def"
-            and detail["id"] == "2"
-            and source == "com.test.0"
-            and detail_type == "foo"
-        )
-        LOG.debug("matched: %s", matched)
-        return matched
-    except Exception as e:
+        assert detail["abc"] == "def"
+        assert detail["id"] == "2"
+        assert source == "com.test.0"
+        assert detail_type == "foo"
+        LOG.debug("matched: %s", True)
+    except AssertionError as e:
         LOG.debug("error: %s", e)
-        return False
+        raise
 
 
-def condition_func_1(received: str) -> bool:
+def assertion_func_1(received: str) -> bool:
     LOG.debug("received: %s", received)
-    return received == '"hello, world!"'
+    assert received == '"hello, world!"'
 
 
-def condition_func_2(received: str) -> bool:
+def assertion_func_2(received: str) -> bool:
     LOG.debug("received: %s", received)
-    return received == '"xyz"'
+    assert received == '"xyz"'
 
 
-def condition_func_3(received: str) -> bool:
+def assertion_func_3(received: str) -> bool:
     LOG.debug("received: %s", received)
-    return received == '{"source": "com.test.3", "foo": "bar"}'
+    assert received == '{"source": "com.test.3", "foo": "bar"}'
 
 @dataclass
 class EbConfiguration:
@@ -219,7 +216,7 @@ class TestZion_wait_until_event_matched(TestCase):
                         detail={"id": "0", "abc": "def"},
                     ),
                 ],
-                condition_func_0,
+                assertion_func_0,
                 10,
             ),
             (
@@ -251,7 +248,7 @@ class TestZion_wait_until_event_matched(TestCase):
                         detail={"id": "0", "abc": "def"},
                     ),
                 ],
-                condition_func_1,
+                assertion_func_1,
                 5,
             ),
             (
@@ -283,7 +280,7 @@ class TestZion_wait_until_event_matched(TestCase):
                         detail={"id": "2", "abc": "def"},
                     ),
                 ],
-                condition_func_2,
+                assertion_func_2,
                 5,
             ),
             (
@@ -315,7 +312,7 @@ class TestZion_wait_until_event_matched(TestCase):
                         detail={"id": "0", "abc": "def", "foo": "bar"},
                     ),
                 ],
-                condition_func_3,
+                assertion_func_3,
                 5,
             ),
         ]
@@ -324,7 +321,7 @@ class TestZion_wait_until_event_matched(TestCase):
         self,
         listener_idx: int,
         events: List[EbEvent],
-        condition_func: Callable[[str], bool],
+        assertion_fn: Callable[[str], None],
         timeout_seconds: int,
     ):
         LOG.debug("purging listener to delete events from previous tests")
@@ -336,7 +333,7 @@ class TestZion_wait_until_event_matched(TestCase):
         LOG.debug("waiting for event")
         found = self.zion.wait_until_event_matched(
             listener_id=self.listener_ids[listener_idx],
-            condition=condition_func,
+            assertion_fn=assertion_fn,
             timeout_seconds=timeout_seconds
         )
         self.assertTrue(found)
@@ -346,7 +343,7 @@ class TestZion_wait_until_event_matched(TestCase):
             (  # no event is sent
                 0,
                 [],
-                condition_func_0,
+                assertion_func_0,
                 10,
             ),
             (  # all events don't match
@@ -373,7 +370,7 @@ class TestZion_wait_until_event_matched(TestCase):
                         detail={"id": "0", "abc": "def"},
                     ),
                 ],
-                condition_func_2,
+                assertion_func_2,
                 5,
             ),
         ]
@@ -382,7 +379,7 @@ class TestZion_wait_until_event_matched(TestCase):
         self,
         listener_idx: int,
         events: List[EbEvent],
-        condition_func: Callable[[str], bool],
+        assertion_fn: Callable[[str], None],
         timeout_seconds: int,
     ):
         LOG.debug("purging listener to delete events from previous tests")
@@ -394,7 +391,7 @@ class TestZion_wait_until_event_matched(TestCase):
         LOG.debug("waiting for event")
         found = self.zion.wait_until_event_matched(
             listener_id=self.listener_ids[listener_idx],
-            condition=condition_func,
+            assertion_fn=assertion_fn,
             timeout_seconds=timeout_seconds
         )
         self.assertFalse(found)
@@ -404,7 +401,7 @@ class TestZion_wait_until_event_matched(TestCase):
         with self.assertRaises(InvalidParamException):
             self.zion.wait_until_event_matched(
                 listener_id=self.listener_ids[listener_idx],
-                condition=condition_func_0,
+                assertion_fn=assertion_func_0,
                 timeout_seconds=10000
             )
 

--- a/python-client/tests/unit/test_retry_until.py
+++ b/python-client/tests/unit/test_retry_until.py
@@ -20,7 +20,7 @@ class TestZion_retry_until_timeout(TestCase):
     def test_retry_timeout_is_default_fail(self):
         def num_is_ten(val):
             return val == 10
-        @self.zion.retry_until(condition=num_is_ten)
+        @self.zion.retry_until(assertion_fn=num_is_ten)
         def num_add_one_slow():
             self.num = self.num + 1
             return self.num
@@ -34,7 +34,7 @@ class TestZion_retry_until_timeout(TestCase):
     def test_retry_timeout_is_default_pass(self):
         def num_is_five(val):
             return val == 5
-        @self.zion.retry_until(condition=num_is_five)
+        @self.zion.retry_until(assertion_fn=num_is_five)
         def num_add_one():
             self.num = self.num + 1
             return self.num
@@ -49,7 +49,7 @@ class TestZion_retry_until_timeout(TestCase):
     def test_retry_timeout_is_infinite(self):
         def num_is_ten(val):
             return val == 10
-        @self.zion.retry_until(condition=num_is_ten, timeout=0)
+        @self.zion.retry_until(assertion_fn=num_is_ten, timeout=0)
         def num_add_one_slow():
             time.sleep(2)
             self.num = self.num + 1
@@ -61,20 +61,20 @@ class TestZion_retry_until_timeout(TestCase):
         self.assertEqual(self.num, 10)
         self.assertTrue(response)
 
-    def test_retry_condition_not_function_error(self):
+    def test_retry_assertion_fn_not_function_error(self):
         with pytest.raises(TypeError) as e:  
-            @self.zion.retry_until(condition=0, timeout=5)
+            @self.zion.retry_until(assertion_fn=0, timeout=5)
             def num_add_one():
                 self.num = self.num + 1
                 return self.num 
             num_add_one()
-            self.assertEqual(e, "condition is not a callable function")
+            self.assertEqual(e, "assertion_fn is not a callable function")
     
     def test_retry_timeout_wrong_type_error(self):
         def num_is_ten(val):
-            return val == 10
+            assert val == 10
         with pytest.raises(TypeError) as e:  
-            @self.zion.retry_until(condition=num_is_ten, timeout="test")
+            @self.zion.retry_until(assertion_fn=num_is_ten, timeout="test")
             def num_add_one():
                 self.num = self.num + 1
                 return self.num 
@@ -83,9 +83,9 @@ class TestZion_retry_until_timeout(TestCase):
 
     def test_retry_timeout_less_than_zero_error(self):
         def num_is_ten(val):
-            return val == 10
+            assert val == 10
         with pytest.raises(ValueError) as e:  
-            @self.zion.retry_until(condition=num_is_ten, timeout=-1)
+            @self.zion.retry_until(assertion_fn=num_is_ten, timeout=-1)
             def num_add_one():
                 self.num = self.num + 1
                 return self.num 
@@ -94,8 +94,8 @@ class TestZion_retry_until_timeout(TestCase):
 
     def test_retry_should_pass(self):
         def num_is_five(val):
-            return val == 5
-        @self.zion.retry_until(condition=num_is_five, timeout=5)
+            assert val == 5
+        @self.zion.retry_until(assertion_fn=num_is_five, timeout=5)
         def num_add_one():
             self.num = self.num + 1
             return self.num
@@ -106,8 +106,8 @@ class TestZion_retry_until_timeout(TestCase):
     def test_retry_should_timeout(self):
         start = time.time()
         def num_is_negative(val):
-            return val < 0
-        @self.zion.retry_until(condition=num_is_negative, timeout=5)
+            assert val < 0
+        @self.zion.retry_until(assertion_fn=num_is_negative, timeout=5)
         def num_add_one():
             self.num = self.num + 1
             return self.num
@@ -120,7 +120,7 @@ class TestZion_retry_until_timeout(TestCase):
     def test_retry_should_pass_multiple_arguments(self):
         def num_is_five(val):
             return val == 5
-        @self.zion.retry_until(condition=num_is_five, timeout=5)
+        @self.zion.retry_until(assertion_fn=num_is_five, timeout=5)
         def num_add_one(dummy, dummy1, dummy2="dummy2"):
             self.num = self.num + 1
             return self.num
@@ -131,8 +131,8 @@ class TestZion_retry_until_timeout(TestCase):
     def test_retry_should_timeout_multiple_arguments(self):
         start = time.time()
         def num_is_negative(val):
-            return val < 0
-        @self.zion.retry_until(condition=num_is_negative, timeout=5)
+            assert val < 0
+        @self.zion.retry_until(assertion_fn=num_is_negative, timeout=5)
         def num_add_one(dummy, dummy1, dummy2="dummy2"):
             self.num = self.num + 1
             return self.num


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

The client's wait_until_event_matched's condition argument is a callable that accepts a string and returns a boolean. Currently, returning any truthy/falsey value is valid for this method.

The change makes it so that we expect an assertion to occur and in the callable and it should raise an exception if it fails

### User experience

> Please share what the user experience looks like before and after this change

#### Mandatory Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.