### PR TITLE
fix: move publish-pypi from reusable workflow into base release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
     secrets:
       CI_IAM_ROLE_ARN: ${{ secrets.CI_IAM_ROLE_ARN }}
 
-  # This job builds python client artifacts and publishes them to PyPi
+  # This job builds python client artifacts
   # It returns the provenance information for subsequent jobs to use.
-  release-python-client:
+  build-python-client:
     needs: [get-version, quality-check]
     uses: ./.github/workflows/reusable_release-python-client.yml
     with:
@@ -71,7 +71,25 @@ jobs:
       release_version: ${{ needs.get-version.outputs.RELEASE_VERSION }}
       artifact_name: "python-client-artifacts"
 
-  # This job creates a draft release on GitHub
+  # This job publishes python client artifacts to PyPi
+  # NOTE: This job cannot be moved into reusable workflow. See https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github
+  publish-python-client:
+    needs: [build-python-client]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # OIDC for PyPi Trusted Publisher feature
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: ${{ needs.build-python-client.outputs.artifact_name }}
+          path: ./dist/
+
+      - name: Upload to PyPi prod
+        if: ${{ !inputs.skip_pypi }}
+        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10
+
+  # This job publishes a release note on GitHub
   release-github:
     needs: [get-version, release-python-client]
     runs-on: ubuntu-latest

--- a/.github/workflows/reusable_release-python-client.yml
+++ b/.github/workflows/reusable_release-python-client.yml
@@ -31,11 +31,6 @@ on:
         type: string
         default: "python-client.multiple.intoto.jsonl"
         description: "name of provenance file"
-      skip_pypi:
-        required: false
-        type: boolean
-        default: false
-        description: "boolean to skip publishing to PyPi"
     outputs:
       attestation_hashes:
         description: "Attestation encoded hash for provenance"
@@ -207,19 +202,3 @@ jobs:
       base64-subjects: ${{ needs.collate.outputs.attestation_hashes }}
       upload-assets: false  # we upload its attestation in create_tag job, otherwise it creates a new release
       provenance-name: ${{ inputs.provenance_name }}
-
-  publish:
-    needs: [build-wheels, build-sdist, collate, provenance]
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # OIDC for PyPi Trusted Publisher feature
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: ${{ inputs.artifact_name }}
-          path: ./dist/
-
-      - name: Upload to PyPi prod
-        if: ${{ !inputs.skip_pypi }}
-        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

Moving the "publish to pypi" job from reusable workflow to base workflow in the release pipeline, as PyPi OIDC does not support reusable workflow. See: https://docs.pypi.org/trusted-publishers/troubleshooting/#reusable-workflows-on-github

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

#### Mandatory Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.