### PR TITLE
Add default label Triaging

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_report.yml
@@ -1,6 +1,7 @@
 name: Bug report
 description: Report a reproducible bug to help us improve
 title: "Bug: TITLE"
+labels: ['stage/needs-triage']
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
**Issue number:**

## Summary
Adds the default needs-triage label on all new bug report tickets
### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

#### Mandatory Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.