### PR TITLE
Add Segment with no parent error to be a retryable exception

### DIFF
--- a/python-client/src/aws_iatk/__init__.py
+++ b/python-client/src/aws_iatk/__init__.py
@@ -650,6 +650,9 @@ class AwsIatk:
                  if "trace not found" in str(e):
                     pass
                     raise RetryableException(e)
+                 elif "found a segment" in str(e) and "with no parent" in str(e):
+                    pass
+                    raise RetryableException(e)
                  else:
                     raise IatkException(e, 500)
         try:

--- a/python-client/tests/integration/retry_fetch_trace/test_retry_fetch_until.py
+++ b/python-client/tests/integration/retry_fetch_trace/test_retry_fetch_until.py
@@ -6,6 +6,7 @@ Integration tests for aws_iatk.retry_until
 """
 import logging
 from unittest import TestCase
+from unittest.mock import patch
 import time
 import boto3
 import random
@@ -152,4 +153,18 @@ class TestIatk_retry_fetch_until(TestCase):
         end = time.time()
         self.assertGreaterEqual(end - start, 10)
         self.assertFalse(response)
-    
+        
+    def test_retry_trace_segment_not_found(self):
+        patched_get_trace_tree = IatkException("found a segment 123456789 with no parent", 500)
+        with patch("aws_iatk.AwsIatk._get_trace_tree", return_value=patched_get_trace_tree):
+            def num_is_5(trace):
+                assert random.randrange(0,5) == 5
+            start = time.time()
+            response = self.iatk.retry_get_trace_tree_until(
+                tracing_header="Root=1-652850da-255d5ae071f55e4aef339837;Sampled=1",
+                assertion_fn=num_is_5,
+                timeout_seconds=10,
+            )
+            end = time.time()
+            self.assertGreaterEqual(end - start, 10)
+            self.assertFalse(response)


### PR DESCRIPTION
**Issue number:**
https://github.com/awslabs/aws-iatk/issues/106
## Summary
In the `retry_get_trace_tree_until` function, an error may occur with the trace not being fully updated before being fetched resulting in a segment not having a parent when it should have one. To fix this, it is now added to a list of retryable exceptions, so instead of throwing the error, the function instead will now re-fetch the trace again until no errors occur

### Changes

> Please provide a summary of what's being changed

### User experience

> Please share what the user experience looks like before and after this change

#### Mandatory Checklist
If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.