### PR TITLE
fix: upgrade mkdocs-material to 9.5.32

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 # Dependencies to render the website needed by mkdocs.
 mkdocs-git-revision-date-plugin==0.3.2
-mkdocs-material==9.4.4
+mkdocs-material==9.5.32


### PR DESCRIPTION
Upgrades mkdocs-material dependency from 9.4.4 to 9.5.32 which includes security improvements.

No functional changes to documentation content or search functionality.